### PR TITLE
使用gitignore将.github文件夹排除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+#github config
+.github


### PR DESCRIPTION
```.github```文件夹中都是相关GitHub仓库的配置文件。在fork时不需要将其同步。